### PR TITLE
Move matrix setup into reusable workflow

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -3,12 +3,6 @@ name: Rust Test
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
-      toolchain:
-        required: true
-        type: string
       working-directory:
         default: "."
         required: false
@@ -19,7 +13,12 @@ env:
 
 jobs:
   test:
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        toolchain: [stable, nightly]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -27,14 +26,14 @@ jobs:
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ inputs.toolchain }}
+          toolchain: ${{ matrix.toolchain }}
 
       - name: Install dependencies
-        if: ${{ inputs.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt update && sudo apt install libomp-dev
 
       - name: Install dependencies
-        if: ${{ inputs.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-latest' }}
         run: brew install llvm libomp cmake
 
       - name: Run cargo check


### PR DESCRIPTION
I didn't realize how the `matrix` variables would apply when consuming the reusable workflows. Instead of running `test_clang10` once for the whole CI run, it ran with each OS + Toolchain combination.

We don't really need the OS + Toolchain matrix to exist in the upstream. I was mostly just being clever if we wanted to disable Mac or enable Windows on individual repos, etc. But in the interest of speed and uniformity, I think we should just move the matrix inside this workflow.

Here's an example on a run: https://github.com/noir-lang/aztec-connect/actions/runs/3962512681 

<img width="323" alt="Screen Shot 2023-01-19 at 2 31 25 PM" src="https://user-images.githubusercontent.com/992373/213566698-1437f7b4-6478-4a26-9388-1d665ab41e85.png">

The above is much better than with my mistake about matrixes (seen below):

<img width="318" alt="Screen Shot 2023-01-19 at 2 31 45 PM" src="https://user-images.githubusercontent.com/992373/213566786-a481d923-6a09-4e9d-adde-59070c81992f.png">
