### PR TITLE
chore(ci): Add reusable spellcheck workflow

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,25 @@
+name: Spellcheck
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        default: "."
+        required: false
+        type: string
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Check spelling
+        uses: streetsidesoftware/cspell-action@v2
+        with:
+          root: ${{ inputs.working-directory }}
+          strict: false # Do not fail, if a spelling mistake is found (This can be annoying for contributors)
+          incremental_files_only: true # Run this action on files which have changed in PR
+          files: |
+            **/*.{md,rs}


### PR DESCRIPTION
This adds a reusable workflow for spellchecking. We've added this to acvm and noir already, so I figured we should make it reusable.

It's worth noting that this uses the cspell.json file from the project calling this workflow, so we don't have a shared dictionary yet. I don't think it'll be too hard to add a shared dictionary in the future if we want it.