### PR TITLE
feat: add MSRV to matrix

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: [stable]
+        toolchain: [1.66.0, stable]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: [1.66.0, stable]
+        toolchain: [1.66.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
I've added the new MSRV of 1.66.0 to the testing matrix to ensure that we always support that version.