### PR TITLE
fix(ci): Add names to jobs to avoid reflecting changes in names

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   clippy:
-    name: clippy
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   clippy:
+    name: clippy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust-format.yml
+++ b/.github/workflows/rust-format.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   format:
-    name: format
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust-format.yml
+++ b/.github/workflows/rust-format.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   format:
+    name: format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    name: test on ${{ matrix.name }}
+    name: Test on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -48,7 +48,7 @@ jobs:
           cargo test -- --test-threads=1
 
   test_clang10:
-    name: test w/ clang 10
+    name: Test with clang 10
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -13,12 +13,18 @@ env:
 
 jobs:
   test:
+    name: test on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        toolchain: [1.66.0]
+        include:
+          - name: ubuntu
+            os: ubuntu-latest
+            toolchain: 1.66.0
+          - name: mac
+            os: macos-latest
+            toolchain: 1.66.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -42,6 +48,7 @@ jobs:
           cargo test -- --test-threads=1
 
   test_clang10:
+    name: test w/ clang 10
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   spellcheck:
-    name: spellcheck
+    name: Spellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   spellcheck:
+    name: spellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Since there is no name on our jobs, GitHub defaults to adding the matrix into the name. e.g. `(ubuntu-latest, 1.66.0)` which is different than `(ubuntu-latest, stable)`. Any changes to the matrix causes any of our required checks to be unavailable. This names our jobs so they can stay consistent even as we iterate the workflows.