### PR TITLE
fix(ci): Remove cache for clippy & format workflows

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -28,17 +28,6 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt install libomp-dev
 
-      - name: Setup cargo cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Run cargo clippy
         working-directory: ${{ inputs.working-directory }}
         run: |

--- a/.github/workflows/rust-format.yml
+++ b/.github/workflows/rust-format.yml
@@ -28,17 +28,6 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt install libomp-dev
 
-      - name: Setup cargo cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Run cargo fmt
         working-directory: ${{ inputs.working-directory }}
         run: |


### PR DESCRIPTION
We merged the cache code this morning, which seems to be working for the rust tests but (for some reason unknown to me) it crashes when building BB during the `clippy` workflow. These 2 workflows were just restoring the cache to make them faster, but we can remove it if they aren't working correctly.