### PR TITLE
feat: fail if lockfile isn't up to date

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run cargo clippy
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo clippy --frozen -- -D warnings
+          cargo clippy --locked -- -D warnings

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run cargo clippy
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo clippy -- -D warnings
+          cargo clippy --frozen -- -D warnings

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -106,4 +106,4 @@ jobs:
       - name: Run cargo test
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo test -- --test-threads=1
+          cargo test --frozen -- --test-threads=1

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run cargo test
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo test -- --test-threads=1
+          cargo test --locked -- --test-threads=1
 
   test_clang10:
     name: Test with clang 10

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -106,4 +106,4 @@ jobs:
       - name: Run cargo test
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo test --frozen -- --test-threads=1
+          cargo test --locked -- --test-threads=1


### PR DESCRIPTION
We currently don't have ~~frozen~~ locked lockfiles when running CI so it can lead to situations like [this](https://github.com/noir-lang/noir/pull/802#issuecomment-1431413491) where CI passes for a commit where if you build it you'll end up with a completely different lockfile.

This PR ensures that CI will fail in these cases.