### PR TITLE
fix(ci): Only use locked flag if lockfile exists

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -28,7 +28,14 @@ jobs:
       - name: Install dependencies
         run: sudo apt update && sudo apt install libomp-dev
 
+      - name: Check for lockfile
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ -f Cargo.lock ]; then
+            echo "LOCKED_FLAG=--locked" >> $GITHUB_ENV
+          fi
+
       - name: Run cargo clippy
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo clippy --locked -- -D warnings
+          cargo clippy ${{ env.LOCKED_FLAG }} -- -D warnings

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -60,10 +60,17 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Check for lockfile
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ -f Cargo.lock ]; then
+            echo "LOCKED_FLAG=--locked" >> $GITHUB_ENV
+          fi
+
       - name: Run cargo test
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo test --locked -- --test-threads=1
+          cargo test ${{ env.LOCKED_FLAG }} -- --test-threads=1
 
   test_clang10:
     name: Test with clang 10
@@ -103,7 +110,14 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Check for lockfile
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ -f Cargo.lock ]; then
+            echo "LOCKED_FLAG=--locked" >> $GITHUB_ENV
+          fi
+
       - name: Run cargo test
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo test --locked -- --test-threads=1
+          cargo test ${{ env.LOCKED_FLAG }} -- --test-threads=1


### PR DESCRIPTION
This adds a check to see if `Cargo.lock` exists before using the `--locked` flag. Our library projects, such as `acvm`, don't use lockfiles, as recommended by rust guidelines. This caused the tests to fail.

Test runs with this branch on Noir (locked) and Acvm (not locked):
* https://github.com/noir-lang/noir/actions/runs/4195392462
* https://github.com/noir-lang/acvm/actions/runs/4195384914