### PR TITLE
feat(ci): run tests from all crates in workspace

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run cargo test
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo test ${{ env.LOCKED_FLAG }} -- --test-threads=1
+          cargo test ${{ env.LOCKED_FLAG }} --workspace -- --test-threads=1
 
   test_clang10:
     name: Test with clang 10
@@ -120,4 +120,4 @@ jobs:
       - name: Run cargo test
         working-directory: ${{ inputs.working-directory }}
         run: |
-          cargo test ${{ env.LOCKED_FLAG }} -- --test-threads=1
+          cargo test ${{ env.LOCKED_FLAG }} --workspace -- --test-threads=1


### PR DESCRIPTION
We're currently only running the tests in the default crates in each workspace, e.g. for `noir-lang/noir` we're not running any tests outside of the `nargo` crate.

We should definitely be checking the other crates for correctness (realistically we should be pushing test coverage further down so we rely less on expensive integration tests) so I've updated the workflows to run tests for every crate in the workspace.