### PR TITLE
feat: Introduce generic organization issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug Report
+description: File a bug report to help us improve.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+        Thanks for taking the time to fill out this bug report to help us improve Noir!
+  - type: textarea
+    id: aim
+    attributes:
+      label: Aim
+      description: Describe what you tried to achieve.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: bug
+    attributes:
+      label: Bug
+      description: Describe the bug. Supply error codes / terminal logs if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To reproduce
+      description: Describe the steps to reproduce the behavior.
+      value: |
+        1.
+        2.
+        3.
+        4.
+  - type: markdown
+    attributes:
+      value: |
+        ## Environment
+        Specify the versions and environment details that were having these issues.
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: Please provide version details and other environment configuration that exhibited the bug.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Please provide any additional context that may be applicable.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an idea for this project.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+        Thanks for taking the time to fill out this feature request to help us improve Noir!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the problem your suggestion sets out to solve.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe your proposed solution.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions you have considered.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Please provide any additional context that may be applicable.


### PR DESCRIPTION
This introduces organization defaults for issue templates. Instead of markdown issue templates, I've setup things to use [GitHub Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms). I like these issue forms because we can provide a lot of extra information to submitters that isn't leaked into the issue body, and we don't need to use comments.

You can see my experiments at https://github.com/noir-lang/mq-tests/issues/new?assignees=&labels=bug&template=bug-report.yml and these will also render as forms if you look directly on my branch (uncertain about the diff).

I made these quite generic since they apply to every repository in the organization unless we override them. Once we land this, I plan to experiment a bit with overrides—e.g. can we override **just** the bug_report.yml template in the noir repo.

Copying @Globallager because I think he set up the original templates.