### PR TITLE
fix(ci): Remove cargo cache

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -66,17 +66,6 @@ jobs:
             ~/noir_cache/
           key: noir_cache
 
-      - name: Setup cargo cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Check for lockfile
         working-directory: ${{ inputs.working-directory }}
         run: |


### PR DESCRIPTION
This removes the cargo cache for our Rust GitHub action. For some reason, whenever our master branch builds a linux cache, all builds that use that cache start crashing with the error: ```error: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /home/runner/work/noir/noir/target/debug/deps/libserde_derive-8f91caaa66184acb.so)```

I think we should just remove the cache.