### PR TITLE
chore(github): Add GitHub Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!-- Thanks for taking the time to improve Noir! -->
+<!-- Please fill out all fields marked with an asterisk (*). -->
+
+# Description
+
+## Problem\*
+
+<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->
+
+Resolves <!-- Link to GitHub Issue -->
+
+## Summary\*
+
+<!-- Describe the changes in this PR, particularly breaking changes if any. -->
+
+This PR sets out to
+
+### Example
+
+<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->
+
+Before:
+
+```
+
+```
+
+After:
+
+```
+
+```
+
+## Additional Context
+
+<!-- Supplement further information if applicable. -->
+
+# PR Checklist\*
+
+- [ ] I have tested the changes locally.
+- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


### PR DESCRIPTION
Extension of https://github.com/noir-lang/noir/pull/1370.

"Documentation" section was removed versus the original PR as the section is best paired with the doc-related GitHub actions to work in its full automated glory, but GitHub actions require manual setup on a per repo basis(?)