### PR TITLE
chore(github): Remove PR template's example section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,25 +11,8 @@ Resolves <!-- Link to GitHub Issue -->
 
 ## Summary\*
 
-<!-- Describe the changes in this PR, particularly breaking changes if any. -->
-
-This PR sets out to
-
-### Example
-
-<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->
-
-Before:
-
-```
-
-```
-
-After:
-
-```
-
-```
+<!-- Describe the changes in this PR. -->
+<!-- Supplement code examples and highlight breaking changes, if applicable. -->
 
 ## Additional Context
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

The "Example" section is not commonly applicable to PRs and can be distracting.

## Summary\*

This PR removes the section and adds a minor reminder in the template on supplementing examples whenever applicable.

## Additional Context

Followup PR of https://github.com/noir-lang/noir/pull/1684.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
