### PR TITLE
chore(github): Add "Idea Action Plan" Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/idea_action_plan.yml
+++ b/.github/ISSUE_TEMPLATE/idea_action_plan.yml
@@ -1,0 +1,54 @@
+name: Idea Action Plan
+description: Outline the scope and steps for implementing an enhancement. Start with "Ideas" instead to request and discuss new features.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Description
+        Thanks for taking the time to create the Issue, and welcome to the Noirot family!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe what you feel lacking. Supply code / step-by-step examples if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Happy Case
+      description: Describe how you think it should work. Supply pseudocode / step-by-step examples if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe less-happy cases you have considered, if any.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Supplement further information if applicable.
+  - type: markdown
+    attributes:
+      value: |
+        ## Pull Request
+  - type: dropdown
+    id: pr-preference
+    attributes:
+      label: Would you like to submit a PR for this Issue?
+      description: Fellow contributors are happy to provide support where applicable.
+      multiple: false
+      options:
+        - "No"
+        - "Maybe"
+        - "Yes"
+    validations:
+      required: true
+  - type: textarea
+    id: pr-support
+    attributes:
+      label: Support Needs
+      description: Support from other contributors you are looking for to create a PR for this Issue.


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

As brought up in https://github.com/noir-lang/noir/pull/2672#issuecomment-1717667137 and first-hand experiences, the removal of the "Feature Request" GitHub Issue template in https://github.com/noir-lang/.github/pull/26 adds extra frictions to creating well-defined enhancement issues ready to be worked on.

## Summary\*

This PR restores the issue template as "Idea Action Plan" for better clarity on the distinctions between:
- **"Ideas" (GitHub Discussions)** that could use further grooming, discussing and upvoting
- **"Idea Action Plan" (GitHub Issue)** as scoped and directly tacklable tasks

## Additional Context

Demo: https://github.com/noir-lang-test/.github/issues/new/choose

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
