### PR TITLE
chore(github): Suspend GitHub Discussions Ideas and revert to feature request issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,0 @@
-contact_links:
-  - name: Ideas
-    url: https://github.com/orgs/noir-lang/discussions/new?category=ideas
-    about: Share ideas for new features

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
-name: Idea Action Plan
-description: Outline the scope and steps for implementing an enhancement. Start with "Ideas" instead to request and discuss new features.
+name: Feature Request
+description: Suggest an idea for this project.
 labels: ["enhancement"]
 body:
   - type: markdown


### PR DESCRIPTION
# Description

## Problem\*

The move towards using GitHub Discussions to suggest ideas was found premature following https://github.com/noir-lang/.github/pull/26, as it introduced additional frictions to switch between Issues / Discussions in order to distill ideas raised by the community.

## Summary\*

Until we can formally define how the Ideas section in GitHub Discussions should be used, this PR reverts the repo back to using GitHub Issues for feature requests for us to move faster in the meantime.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
